### PR TITLE
Fix ARMv7 support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.pyoncord.xposed"
         minSdk = 24
         targetSdk = 33
-        versionCode = 202
-        versionName = "0.2.2"
+        versionCode = 203
+        versionName = "0.2.3"
     }
 
     buildTypes {

--- a/app/src/main/kotlin/io/github/pyoncord/xposed/Main.kt
+++ b/app/src/main/kotlin/io/github/pyoncord/xposed/Main.kt
@@ -58,14 +58,14 @@ class Main : IXposedHookLoadPackage {
         for (module in pyonModules) module.onInit(param)
 
         val loadScriptFromAssets = catalystInstanceImpl.getDeclaredMethod(
-            "jniLoadScriptFromAssets",
+            "loadScriptFromAssets",
             AssetManager::class.java,
             String::class.java,
             Boolean::class.javaPrimitiveType
         ).apply { isAccessible = true }
 
         val loadScriptFromFile = catalystInstanceImpl.getDeclaredMethod(
-            "jniLoadScriptFromFile",
+            "loadScriptFromFile",
             String::class.java,
             String::class.java,
             Boolean::class.javaPrimitiveType


### PR DESCRIPTION
Hooks non-`jni`-prefixed methods instead which [internally calls the `jni`-prefixed methods](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java#L236-L243) anyway.